### PR TITLE
Update init-script.sh for Amazon Linux 2 instance

### DIFF
--- a/init-script.sh
+++ b/init-script.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 yum update -y
-yum -y remove httpd
-yum -y remove httpd-tools
-yum install -y httpd24 php72 mysql57-server php72-mysqlnd
-service httpd start
-chkconfig httpd on
+amazon-linux-extras install -y lamp-mariadb10.2-php7.2 php7.2
+yum install -y httpd mariadb-server
+systemctl start httpd
+systemctl enable httpd
 
 usermod -a -G apache ec2-user
 chown -R ec2-user:apache /var/www


### PR DESCRIPTION
There are some changes to spin up the LAMP web server on Amazon Linux 2.

Replaced several steps in the user_data script according to the document: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-lamp-amazon-linux-2.html